### PR TITLE
Fix tailwind-config option path resolution

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,6 @@
 import * as elmTailwindModules from "./index";
 import { program } from "commander";
+import { join } from "path";
 
 program.name("elm-tailwind-modules");
 program.version("0.3.0");
@@ -13,7 +14,9 @@ program.option("--with-docs", `Add documentation to the generated modules (defau
 
     const options = program.opts();
 
-    const tailwindConfig = options.tailwindConfig == null ? elmTailwindModules.defaultTailwindConfig : await import(options.tailwindConfig);
+    const tailwindConfig = options.tailwindConfig == null
+        ? elmTailwindModules.defaultTailwindConfig
+        : await import(join(process.cwd(), options.tailwindConfig));
 
     elmTailwindModules.run({
         directory: options.dir,


### PR DESCRIPTION
Fixes #1 .

**Goal**

Say a have a project with the structure like this:

```
/my-project
  package.json
  tailwind.config.js
```

This change makes it possible to call the `--tailwind-config` like this:

```
elm-tailwind-modules --tailwind-config ./tailwind.config.js
```

**Problem**

Currently, I need to specify to full relative path based on the internal structure of the publish elm-tailwind-modules package:

```
elm-tailwind-modules --tailwind-config ../../../tailwind.config.js
```

**Why it was happening**

Since the option accepts a regular string, by passing that value to `await import` the library was importing a file based on the current file position (e.g. `node_modules/elm-tailwind-modules/dist/cli.js` when using it as an external dependency). We need to the caller position so the imported path makes sense for the end user (e.g. calling it from an npm script).