### PR TITLE
Allow Tailwind 3 (^3.1.6) as peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "peerDependencies": {
     "postcss": "^8.2.4",
-    "tailwindcss": "^2.0.2"
+    "tailwindcss": "^2.0.2 || ^3.1.6"
   },
   "main": "dist/index.js",
   "module": "dist/index.es.js",


### PR DESCRIPTION
elm-tailwind-modules 0.4.0 added support for Tailwind CSS v3, however this was not reflected in the `peerDependencies` declaration. This commit catches up on this and now allows all tailwind v2 versions >= 2.0.2 and all tailwind v3 versions >= 3.1.6.

Fixes #14.