### PR TITLE
Pin tailwindcss to <3.3.0 due to incompatible change

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,14 +50,14 @@
     "magic-string": "^0.25.7",
     "postcss": "^8.4.14",
     "rimraf": "^3.0.2",
-    "tailwindcss": "^3.1.6",
+    "tailwindcss": ">=3.1.6 <3.3.0",
     "ts-node": "^9.1.1",
     "typedoc": "^0.20.36",
     "typescript": "4.2.4"
   },
   "peerDependencies": {
     "postcss": "^8.2.4",
-    "tailwindcss": "^2.0.2 || ^3.1.6"
+    "tailwindcss": "^2.0.2 || >=3.1.6 <3.3.0"
   },
   "main": "dist/index.js",
   "module": "dist/index.es.js",


### PR DESCRIPTION
This is a quickfix for #25 for the master branch.